### PR TITLE
Improve logging

### DIFF
--- a/rl/callbacks.py
+++ b/rl/callbacks.py
@@ -197,6 +197,7 @@ class TrainIntervalLogger(Callback):
         self.interval_start = timeit.default_timer()
         self.progbar = Progbar(target=self.interval)
         self.metrics = []
+        self.episode_rewards = []
 
     def on_train_begin(self, logs):
         self.train_start = timeit.default_timer()
@@ -209,6 +210,9 @@ class TrainIntervalLogger(Callback):
 
     def on_step_begin(self, step, logs):
         if self.step % self.interval == 0:
+            if len(self.episode_rewards) > 0:
+                print('performed {} episodes, episode_reward={:.3f} [{:.3f}, {:.3f}]'.format(len(self.episode_rewards), np.mean(self.episode_rewards), np.min(self.episode_rewards), np.max(self.episode_rewards)))
+                print('')
             self.reset()
             print('Interval {} ({} steps performed)'.format(self.step // self.interval + 1, self.step))
 
@@ -234,6 +238,9 @@ class TrainIntervalLogger(Callback):
         self.progbar.update((self.step % self.interval) + 1, values=values, force=True)
         self.step += 1
         self.metrics.append(logs['metrics'])
+
+    def on_episode_end(self, episode, logs):
+        self.episode_rewards.append(logs['episode_reward'])
 
 
 class FileLogger(Callback):


### PR DESCRIPTION
The way `TrainIntervalLogger` was implemented was rather suboptimal. First, the estimates were slightly incorrect since we tried to work around the `NaN`s that were reported if no training step occurred. Secondly, computing the over the interval history in every single time step was terribly inefficient and slowed down training quite a lot.

Both problems have been addressed for the sake of losing real-time estimates. This might be re-implemented properly in the feature but for now this is far better than having estimates that are off and slow to compute.

The new output looks like that:
```
...
Interval 6 (50000 steps performed)
10000/10000 [==============================] - 40s - reward: 0.0054
308 episodes - episode_reward: 0.175 [0.000, 2.000] - loss: 0.008 - mean_q_new: -0.013 - mean_eps: 0.951

Interval 7 (60000 steps performed)
10000/10000 [==============================] - 38s - reward: 0.0052
315 episodes - episode_reward: 0.165 [0.000, 4.000] - loss: 0.003 - mean_q_new: 0.018 - mean_eps: 0.942

Interval 8 (70000 steps performed)
10000/10000 [==============================] - 38s - reward: 0.0061
293 episodes - episode_reward: 0.208 [0.000, 2.000] - loss: 0.002 - mean_q_new: 0.028 - mean_eps: 0.933

Interval 9 (80000 steps performed)
10000/10000 [==============================] - 38s - reward: 0.0059
299 episodes - episode_reward: 0.197 [0.000, 4.000] - loss: 0.002 - mean_q_new: 0.029 - mean_eps: 0.924
...
```