### PR TITLE
Add correct dimensionality for the OUProcess

### DIFF
--- a/examples/ddpg_pendulum.py
+++ b/examples/ddpg_pendulum.py
@@ -52,7 +52,7 @@ print(critic.summary())
 # Finally, we configure and compile our agent. You can use every built-in Keras optimizer and
 # even the metrics!
 memory = SequentialMemory(limit=100000, window_length=1)
-random_process = OrnsteinUhlenbeckProcess(theta=.15, mu=0., sigma=.3)
+random_process = OrnsteinUhlenbeckProcess(size=nb_actions, theta=.15, mu=0., sigma=.3)
 agent = DDPGAgent(nb_actions=nb_actions, actor=actor, critic=critic, critic_action_input=action_input,
                   memory=memory, nb_steps_warmup_critic=100, nb_steps_warmup_actor=100,
                   random_process=random_process, gamma=.99, target_model_update=1e-3)


### PR DESCRIPTION
This does not fix this very example but solves a problem as soon as somebody builds an example which has more than one dimension based on this one.

I was just about to write my own OUProcess based on your when I realized that it has the size parameter. Since my example is a cartpole moving in a plane (2 continuous actions), I needed 2D OrnsteinUhlenbeckNoise. Otherwise I received a failing assert noise.shape == action_space.shape. So maybe this saves somebody a quarter of an hour of searching for the problem.