### PR TITLE
Add the dueling network to DQNAgent

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ As of today, the following algorithms have been implemented:
 - Deep Deterministic Policy Gradient (DDPG) [[4]](http://arxiv.org/abs/1509.02971)
 - Continuous DQN (CDQN or NAF) [[6]](http://arxiv.org/abs/1603.00748)
 - Cross-Entropy Method (CEM) [[7]](http://learning.mpi-sws.org/mlss2016/slides/2016-MLSS-RL.pdf), [[8]](http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.81.6579&rep=rep1&type=pdf)
+- Dueling network DQN (Dueling DQN) [[9]](https://arxiv.org/abs/1511.06581)
 
 You can find more information on each agent in the [wiki](https://github.com/matthiasplappert/keras-rl/wiki/Agent-Overview).
 
@@ -131,6 +132,7 @@ It has since been adapted to become a general-purpose library.
 6. *Continuous Deep Q-Learning with Model-based Acceleration*, Gu et al., 2016
 7. *Learning Tetris Using the Noisy Cross-Entropy Method*, Szita et al., 2006
 8. *Deep Reinforcement Learning (MLSS lecture notes)*, John Schulman, 2016.
+9. *Dueling Network Architectures for Deep Reinforcement Learning*, Ziyu Wang et al., 2016.
 
 ## Todos
 - Tests: I haven't yet had time to get started, but this is important.

--- a/examples/duel_dqn_cartpole.py
+++ b/examples/duel_dqn_cartpole.py
@@ -19,13 +19,18 @@ np.random.seed(123)
 env.seed(123)
 nb_actions = env.action_space.n
 
-# Next, we build a very simple model.
+# Next, we build a very simple model regardless of the dueling architecture
+# if you enable dueling network in DQN , DQN will build a dueling network base on your model automatically
+# Also, you can build a dueling network by yourself and turn off the dueling network in DQN.
 model = Sequential()
 model.add(Flatten(input_shape=(1,) + env.observation_space.shape))
 model.add(Dense(16))
 model.add(Activation('relu'))
-model.add(Dense(nb_actions))
-model.add(Activation('linear'))
+model.add(Dense(16))
+model.add(Activation('relu'))
+model.add(Dense(16))
+model.add(Activation('relu'))
+model.add(Dense(nb_actions, activation='linear'))
 print(model.summary())
 
 # Finally, we configure and compile our agent. You can use every built-in Keras optimizer and

--- a/examples/duel_dqn_cartpole.py
+++ b/examples/duel_dqn_cartpole.py
@@ -1,0 +1,50 @@
+import numpy as np
+import gym
+
+from keras.models import Sequential
+from keras.layers import Dense, Activation, Flatten
+from keras.optimizers import Adam
+
+from rl.agents.dqn import DQNAgent
+from rl.policy import BoltzmannQPolicy
+from rl.memory import SequentialMemory
+
+
+ENV_NAME = 'CartPole-v0'
+
+
+# Get the environment and extract the number of actions.
+env = gym.make(ENV_NAME)
+np.random.seed(123)
+env.seed(123)
+nb_actions = env.action_space.n
+
+# Next, we build a very simple model.
+model = Sequential()
+model.add(Flatten(input_shape=(1,) + env.observation_space.shape))
+model.add(Dense(16))
+model.add(Activation('relu'))
+model.add(Dense(nb_actions))
+model.add(Activation('linear'))
+print(model.summary())
+
+# Finally, we configure and compile our agent. You can use every built-in Keras optimizer and
+# even the metrics!
+memory = SequentialMemory(limit=50000, window_length=1)
+policy = BoltzmannQPolicy()
+# enable the dueling network
+# you can specify the dueling_type to one of {'avg','max','naive'}
+dqn = DQNAgent(model=model, nb_actions=nb_actions, memory=memory, nb_steps_warmup=10,
+               enable_dueling_network=True, dueling_type='avg', target_model_update=1e-2, policy=policy)
+dqn.compile(Adam(lr=1e-3), metrics=['mae'])
+
+# Okay, now it's time to learn something! We visualize the training here for show, but this
+# slows down training quite a lot. You can always safely abort the training prematurely using
+# Ctrl + C.
+dqn.fit(env, nb_steps=50000, visualize=False, verbose=2)
+
+# After training is done, we save the final weights.
+dqn.save_weights('duel_dqn_{}_weights.h5f'.format(ENV_NAME), overwrite=True)
+
+# Finally, evaluate our algorithm for 5 episodes.
+dqn.test(env, nb_episodes=5, visualize=False)

--- a/rl/agents/dqn.py
+++ b/rl/agents/dqn.py
@@ -88,8 +88,8 @@ class AbstractDQNAgent(Agent):
 # http://arxiv.org/pdf/1312.5602.pdf
 # http://arxiv.org/abs/1509.06461
 class DQNAgent(AbstractDQNAgent):
-    def __init__(self, model, policy=None, enable_double_dqn=True, enable_dueling_network = False,
-                 dueling_type = 'avg', *args, **kwargs):
+    def __init__(self, model, policy=None, enable_double_dqn=True, enable_dueling_network=False,
+                 dueling_type='avg', *args, **kwargs):
         super(DQNAgent, self).__init__(*args, **kwargs)
 
         # Validate (important) input.
@@ -101,15 +101,15 @@ class DQNAgent(AbstractDQNAgent):
         # Parameters.
         self.enable_double_dqn = enable_double_dqn
         self.enable_dueling_network = enable_dueling_network
-        self.advantage = dueling_type
-        if self.enable_dueling_network is True:
+        self.dueling_type = dueling_type
+        if self.enable_dueling_network:
             # get the second last layer of the model, abandon the last layer
             layer = model.layers[-2]
             nb_action = model.output._keras_shape[-1]
             # layer y has a shape (nb_action+1,)
             # y[:,0] represents V(s;theta)
             # y[:,1:] represents A(s,a;theta)
-            y = Dense(nb_action + 1, activation='relu')(layer.output)
+            y = Dense(nb_action + 1, activation='linear')(layer.output)
             # caculate the Q(s,a;theta)
             # dueling_type == 'avg'
             # Q(s,a;theta) = V(s;theta) + (A(s,a;theta)-Avg_a(A(s,a;theta)))
@@ -117,14 +117,14 @@ class DQNAgent(AbstractDQNAgent):
             # Q(s,a;theta) = V(s;theta) + (A(s,a;theta)-max_a(A(s,a;theta)))
             # dueling_type == 'naive'
             # Q(s,a;theta) = V(s;theta) + A(s,a;theta)
-            if self.advantage == 'avg':
+            if self.dueling_type == 'avg':
                 outputlayer = Lambda(lambda a: K.expand_dims(a[:, 0], dim=-1) + a[:, 1:] - K.mean(a[:, 1:], keepdims=True), output_shape=(nb_action,))(y)
-            elif self.advantage == 'max':
+            elif self.dueling_type == 'max':
                 outputlayer = Lambda(lambda a: K.expand_dims(a[:, 0], dim=-1) + a[:, 1:] - K.max(a[:, 1:], keepdims=True), output_shape=(nb_action,))(y)
-            elif self.advantage == 'naive':
+            elif self.dueling_type == 'naive':
                 outputlayer = Lambda(lambda a: K.expand_dims(a[:, 0], dim=-1) + a[:, 1:], output_shape=(nb_action,))(y)
             else:
-                assert False
+                assert False, "dueling_type must be one of {'avg','max','naive'}"
 
             model = Model(input=model.input, output=outputlayer)
 

--- a/rl/agents/dqn.py
+++ b/rl/agents/dqn.py
@@ -102,7 +102,7 @@ class DQNAgent(AbstractDQNAgent):
         self.enable_double_dqn = enable_double_dqn
         self.enable_dueling_network = enable_dueling_network
         self.advantage = dueling_type
-        if(self.enable_dueling_network == True):
+        if self.enable_dueling_network is True:
             layer = model.layers[-1]
             nb_action = model.output._keras_shape[-1]
             # layer y has a shape (nb_action+1,)
@@ -117,11 +117,9 @@ class DQNAgent(AbstractDQNAgent):
             # dueling_type == 'naive'
             # Q(s,a;theta) = V(s;theta) + A(s,a;theta)
             if self.advantage == 'avg':
-                outputlayer = Lambda(lambda a: K.expand_dims(a[:, 0], dim=-1) + a[:, 1:] - K.mean(a[:, 1:], keepdims=True),
-                           output_shape=(nb_action,))(y)
+                outputlayer = Lambda(lambda a: K.expand_dims(a[:, 0], dim=-1) + a[:, 1:] - K.mean(a[:, 1:], keepdims=True), output_shape=(nb_action,))(y)
             elif self.advantage == 'max':
-                outputlayer = Lambda(lambda a: K.expand_dims(a[:, 0], dim=-1) + a[:, 1:] - K.max(a[:, 1:], keepdims=True),
-                           output_shape=(nb_action,))(y)
+                outputlayer = Lambda(lambda a: K.expand_dims(a[:, 0], dim=-1) + a[:, 1:] - K.max(a[:, 1:], keepdims=True), output_shape=(nb_action,))(y)
             elif self.advantage == 'naive':
                 outputlayer = Lambda(lambda a: K.expand_dims(a[:, 0], dim=-1) + a[:, 1:], output_shape=(nb_action,))(y)
 

--- a/rl/agents/dqn.py
+++ b/rl/agents/dqn.py
@@ -103,7 +103,8 @@ class DQNAgent(AbstractDQNAgent):
         self.enable_dueling_network = enable_dueling_network
         self.advantage = dueling_type
         if self.enable_dueling_network is True:
-            layer = model.layers[-1]
+            # get the second last layer of the model, abandon the last layer
+            layer = model.layers[-2]
             nb_action = model.output._keras_shape[-1]
             # layer y has a shape (nb_action+1,)
             # y[:,0] represents V(s;theta)
@@ -122,6 +123,8 @@ class DQNAgent(AbstractDQNAgent):
                 outputlayer = Lambda(lambda a: K.expand_dims(a[:, 0], dim=-1) + a[:, 1:] - K.max(a[:, 1:], keepdims=True), output_shape=(nb_action,))(y)
             elif self.advantage == 'naive':
                 outputlayer = Lambda(lambda a: K.expand_dims(a[:, 0], dim=-1) + a[:, 1:], output_shape=(nb_action,))(y)
+            else:
+                assert False
 
             model = Model(input=model.input, output=outputlayer)
 

--- a/tests/integration/test_discrete.py
+++ b/tests/integration/test_discrete.py
@@ -86,3 +86,28 @@ def test_cem():
     dqn.fit(env, nb_steps=2000, visualize=False, verbose=1)
     h = dqn.test(env, nb_episodes=20, visualize=False)
     assert_allclose(np.mean(h.history['episode_reward']), 3.)
+
+def test_duel_dqn():
+    env = TwoRoundDeterministicRewardEnv()
+    np.random.seed(123)
+    env.seed(123)
+    random.seed(123)
+    nb_actions = env.action_space.n
+
+    # Next, we build a very simple model.
+    model = Sequential()
+    model.add(Dense(16, input_shape=(1,)))
+    model.add(Activation('relu'))
+    model.add(Dense(nb_actions, activation='linear'))
+
+
+    memory = SequentialMemory(limit=1000, window_length=1)
+    policy = EpsGreedyQPolicy(eps=.1)
+    dqn = DQNAgent(model=model, nb_actions=nb_actions, memory=memory, nb_steps_warmup=50,
+                   target_model_update=1e-1, policy=policy, enable_double_dqn=False, enable_dueling_network=True)
+    dqn.compile(Adam(lr=1e-3))
+
+    dqn.fit(env, nb_steps=2000, visualize=False, verbose=0)
+    policy.eps = 0.
+    h = dqn.test(env, nb_episodes=20, visualize=False)
+    assert_allclose(np.mean(h.history['episode_reward']), 3.)

--- a/tests/integration/test_discrete.py
+++ b/tests/integration/test_discrete.py
@@ -100,7 +100,6 @@ def test_duel_dqn():
     model.add(Activation('relu'))
     model.add(Dense(nb_actions, activation='linear'))
 
-
     memory = SequentialMemory(limit=1000, window_length=1)
     policy = EpsGreedyQPolicy(eps=.1)
     dqn = DQNAgent(model=model, nb_actions=nb_actions, memory=memory, nb_steps_warmup=50,


### PR DESCRIPTION
i try to add the dueling network to dqn. I hope to get your advice

here is how i do it:

- get the second last layer of model passed to the DQNAgent, abandon the last layer

- add a new layer after the second last layer of model with the size (nb_action+1,), which is named as y

1.             # layer y has a shape (nb_action+1,)
2.             # y[:,0] represents V(s;theta)
3.             # y[:,1:] represents A(s,a;theta)

- caculate the Q(s,a;theta) layer as a keras Lambda layer, which is named as outputlayer

1.             # when dueling_type == 'avg'
2.             # Q(s,a;theta) = V(s;theta) + (A(s,a;theta)-Avg_a(A(s,a;theta)))
3.             # when dueling_type == 'max'
4.             # Q(s,a;theta) = V(s;theta) + (A(s,a;theta)-max_a(A(s,a;theta)))
5.             # when dueling_type == 'naive'
6.             # Q(s,a;theta) = V(s;theta) + A(s,a;theta)

- construct a new model

1.            # newmodel = Model(input =model.input, output = outputlayer)

- i write an example of duel dqn for OpenAI CartPole-v0, here is the part of the training logs 

_1.   4260/50000: episode: 125, duration: 1.914s, episode steps: 237, steps per second: 124, episode reward: 237.000, mean reward: 1.000 [1.000, 1.000], mean action: 0.515 [0.000, 1.000], mean observation: 0.258 [-1.459, 2.789], loss: 1.063010, mean_absolute_error: 15.296993, mean_q: 31.297831
2.   4409/50000: episode: 126, duration: 1.223s, episode steps: 149, steps per second: 122, episode reward: 149.000, mean reward: 1.000 [1.000, 1.000], mean action: 0.470 [0.000, 1.000], mean observation: -0.246 [-1.635, 0.717], loss: 1.324580, mean_absolute_error: 16.253447, mean_q: 33.235760
3.   4563/50000: episode: 127, duration: 1.223s, episode steps: 154, steps per second: 126, episode reward: 154.000, mean reward: 1.000 [1.000, 1.000], mean action: 0.461 [0.000, 1.000], mean observation: -0.318 [-2.154, 0.801], loss: 1.413017, mean_absolute_error: 17.135771, mean_q: 35.006638
4.   4811/50000: episode: 128, duration: 1.930s, episode steps: 248, steps per second: 128, episode reward: 248.000, mean reward: 1.000 [1.000, 1.000], mean action: 0.480 [0.000, 1.000], mean observation: -0.160 [-1.783, 0.775], loss: 1.362046, mean_absolute_error: 18.279867, mean_q: 37.348125
5.   5050/50000: episode: 129, duration: 1.885s, episode steps: 239, steps per second: 127, episode reward: 239.000, mean reward: 1.000 [1.000, 1.000], mean action: 0.469 [0.000, 1.000], mean observation: -0.258 [-2.790, 0.984], loss: 1.386958, mean_absolute_error: 19.593142, mean_q: 40.091267
6.   5429/50000: episode: 130, duration: 3.036s, episode steps: 379, steps per second: 125, episode reward: 379.000, mean reward: 1.000 [1.000, 1.000], mean action: 0.512 [0.000, 1.000], mean observation: 0.173 [-1.217, 2.762], loss: 1.914814, mean_absolute_error: 21.176933, mean_q: 43.169743
7.   5614/50000: episode: 131, duration: 1.462s, episode steps: 185, steps per second: 127, episode reward: 185.000, mean reward: 1.000 [1.000, 1.000], mean action: 0.465 [0.000, 1.000], mean observation: -0.336 [-2.584, 0.671], loss: 1.634199, mean_absolute_error: 22.802450, mean_q: 46.470306
8.   5798/50000: episode: 132, duration: 1.465s, episode steps: 184, steps per second: 126, episode reward: 184.000, mean reward: 1.000 [1.000, 1.000], mean action: 0.516 [0.000, 1.000], mean observation: 0.341 [-0.948, 2.276], loss: 1.890901, mean_absolute_error: 23.659718, mean_q: 48.169544
9.   5999/50000: episode: 133, duration: 1.629s, episode steps: 201, steps per second: 123, episode reward: 201.000, mean reward: 1.000 [1.000, 1.000], mean action: 0.517 [0.000, 1.000], mean observation: 0.312 [-0.773, 2.291], loss: 2.066004, mean_absolute_error: 24.598412, mean_q: 50.073372
10.   6175/50000: episode: 134, duration: 1.431s, episode steps: 176, steps per second: 123, episode reward: 176.000, mean reward: 1.000 [1.000, 1.000], mean action: 0.466 [0.000, 1.000], mean observation: -0.308 [-2.174, 0.691], loss: 1.886971, mean_absolute_error: 25.594563, mean_q: 52.077305
11.   6386/50000: episode: 135, duration: 1.747s, episode steps: 211, steps per second: 121, episode reward: 211.000, mean reward: 1.000 [1.000, 1.000], mean action: 0.464 [0.000, 1.000], mean observation: -0.297 [-2.962, 0.804], loss: 1.878460, mean_absolute_error: 26.215256, mean_q: 53.484360
12.   6626/50000: episode: 136, duration: 1.892s, episode steps: 240, steps per second: 127, episode reward: 240.000, mean reward: 1.000 [1.000, 1.000], mean action: 0.471 [0.000, 1.000], mean observation: -0.261 [-2.796, 0.603], loss: 2.331970, mean_absolute_error: 27.323385, mean_q: 55.505970
13.   6877/50000: episode: 137, duration: 2.010s, episode steps: 251, steps per second: 125, episode reward: 251.000, mean reward: 1.000 [1.000, 1.000], mean action: 0.518 [0.000, 1.000], mean observation: 0.247 [-0.890, 2.414], loss: 2.358430, mean_absolute_error: 28.530544, mean_q: 58.037045
14.   7175/50000: episode: 138, duration: 2.377s, episode steps: 298, steps per second: 125, episode reward: 298.000, mean reward: 1.000 [1.000, 1.000], mean action: 0.473 [0.000, 1.000], mean observation: -0.211 [-2.926, 0.878], loss: 2.627178, mean_absolute_error: 29.701906, mean_q: 60.317657
15.   7416/50000: episode: 139, duration: 1.949s, episode steps: 241, steps per second: 124, episode reward: 241.000, mean reward: 1.000 [1.000, 1.000], mean action: 0.523 [0.000, 1.000], mean observation: 0.263 [-0.823, 2.406], loss: 2.652330, mean_absolute_error: 30.846329, mean_q: 62.637028
16.   7578/50000: episode: 140, duration: 1.324s, episode steps: 162, steps per second: 122, episode reward: 162.000, mean reward: 1.000 [1.000, 1.000], mean action: 0.463 [0.000, 1.000], mean observation: -0.369 [-2.767, 0.943], loss: 2.385495, mean_absolute_error: 31.783854, mean_q: 64.615829
17.   7892/50000: episode: 141, duration: 2.503s, episode steps: 314, steps per second: 125, episode reward: 314.000, mean reward: 1.000 [1.000, 1.000], mean action: 0.513 [0.000, 1.000], mean observation: 0.202 [-0.676, 2.407], loss: 2.836606, mean_absolute_error: 32.634499, mean_q: 66.321106
18.   8068/50000: episode: 142, duration: 1.428s, episode steps: 176, steps per second: 123, episode reward: 176.000, mean reward: 1.000 [1.000, 1.000], mean action: 0.460 [0.000, 1.000], mean observation: -0.355 [-2.573, 0.752], loss: 2.669178, mean_absolute_error: 33.854343, mean_q: 68.686623_
