### PR TITLE
Move epsilon outside of exponential

### DIFF
--- a/rl/agents/dqn.py
+++ b/rl/agents/dqn.py
@@ -378,7 +378,7 @@ class NAFLayer(Layer):
                 def fn(x, L_acc, LT_acc):
                     x_ = K.zeros((self.nb_actions, self.nb_actions))
                     x_ = T.set_subtensor(x_[np.tril_indices(self.nb_actions)], x)
-                    diag = K.exp(T.diag(x_) + K.epsilon())
+                    diag = K.exp(T.diag(x_)) + K.epsilon()
                     x_ = T.set_subtensor(x_[np.diag_indices(self.nb_actions)], diag)
                     return x_, x_.T
 
@@ -428,7 +428,7 @@ class NAFLayer(Layer):
                 def fn(a, x):
                     # Exponentiate everything. This is much easier than only exponentiating
                     # the diagonal elements, and, usually, the action space is relatively low.
-                    x_ = K.exp(x + K.epsilon())
+                    x_ = K.exp(x) + K.epsilon()
                     # Only keep the diagonal elements.
                     x_ *= diag_mask
                     # Add the original, non-diagonal elements.


### PR DESCRIPTION
@matthiasplappert thanks for the great library! I'm pretty sure the transform in the cdqn is supposed to be e^(x)+epsilon instead of e^(x+epsilon). This constrains the values to be >0 instead of >=0.

before
```python
diag = K.exp(T.diag(x_) + K.epsilon())
...
x_ = K.exp(x + K.epsilon())
```

after
```python
diag = K.exp(T.diag(x_)) + K.epsilon()
...
x_ = K.exp(x) + K.epsilon()
```

Cheers!