### PR TITLE
Alternative cdqn P parameterization

### DIFF
--- a/examples/cdqn_pendulum.py
+++ b/examples/cdqn_pendulum.py
@@ -103,7 +103,7 @@ def main(argv):
         # Okay, now it's time to learn something! We visualize the training here for show, but this
         # slows down training quite a lot. You can always safely abort the training prematurely using
         # Ctrl + C.
-        agent.fit(env, nb_steps=args.steps, visualize=args.quiet, verbose=1, nb_max_episode_steps=200)
+        agent.fit(env, nb_steps=args.steps, visualize=not args.quiet, verbose=1, nb_max_episode_steps=200)
 
         # After training is done, we save the final weights.
         agent.save_weights(args.path, overwrite=True)

--- a/examples/cdqn_pendulum.py
+++ b/examples/cdqn_pendulum.py
@@ -1,5 +1,7 @@
 import numpy as np
 import gym
+import argparse
+import sys
 
 from keras.models import Sequential
 from keras.layers import Dense, Activation, Flatten, Input
@@ -11,6 +13,7 @@ from rl.random import OrnsteinUhlenbeckProcess
 from rl.core import Processor
 from rl.keras_future import concatenate, Model
 
+
 class PendulumProcessor(Processor):
     def process_reward(self, reward):
         # The magnitude of the reward can be important. Since each step yields a relatively
@@ -19,72 +22,94 @@ class PendulumProcessor(Processor):
 
 
 ENV_NAME = 'Pendulum-v0'
-gym.undo_logger_setup()
 
 
-# Get the environment and extract the number of actions.
-env = gym.make(ENV_NAME)
-np.random.seed(123)
-env.seed(123)
-assert len(env.action_space.shape) == 1
-nb_actions = env.action_space.shape[0]
+def main(argv):
+    default_path = 'cdqn_{}_weights.h5f'.format(ENV_NAME)
+    default_steps = 50000
+    parser = argparse.ArgumentParser(description='Train a CDQN to on Gym environment [{}].'.format(ENV_NAME))
+    parser.add_argument('--path', action="store",
+                        help='path for saving or loading model [default: {}]'.format(default_path))
+    parser.add_argument('--load', action="store_true",
+                        help='load pretrained model instead of training new model')
+    parser.add_argument('--steps', action="store", type=int, default=default_steps,
+                        help='load pretrained model instead of training new model')
+    parser.add_argument('--quiet', action='store_true', help='do not visualize training')
+    args = parser.parse_args(argv)
 
-# Build all necessary models: V, mu, and L networks.
-V_model = Sequential()
-V_model.add(Flatten(input_shape=(1,) + env.observation_space.shape))
-V_model.add(Dense(16))
-V_model.add(Activation('relu'))
-V_model.add(Dense(16))
-V_model.add(Activation('relu'))
-V_model.add(Dense(16))
-V_model.add(Activation('relu'))
-V_model.add(Dense(1))
-V_model.add(Activation('linear'))
-print(V_model.summary())
 
-mu_model = Sequential()
-mu_model.add(Flatten(input_shape=(1,) + env.observation_space.shape))
-mu_model.add(Dense(16))
-mu_model.add(Activation('relu'))
-mu_model.add(Dense(16))
-mu_model.add(Activation('relu'))
-mu_model.add(Dense(16))
-mu_model.add(Activation('relu'))
-mu_model.add(Dense(nb_actions))
-mu_model.add(Activation('linear'))
-print(mu_model.summary())
+    gym.undo_logger_setup()
 
-action_input = Input(shape=(nb_actions,), name='action_input')
-observation_input = Input(shape=(1,) + env.observation_space.shape, name='observation_input')
-x = concatenate([action_input, Flatten()(observation_input)])
-x = Dense(32)(x)
-x = Activation('relu')(x)
-x = Dense(32)(x)
-x = Activation('relu')(x)
-x = Dense(32)(x)
-x = Activation('relu')(x)
-x = Dense(((nb_actions * nb_actions + nb_actions) / 2))(x)
-x = Activation('linear')(x)
-L_model = Model(input=[action_input, observation_input], output=x)
-print(L_model.summary())
 
-# Finally, we configure and compile our agent. You can use every built-in Keras optimizer and
-# even the metrics!
-processor = PendulumProcessor()
-memory = SequentialMemory(limit=100000, window_length=1)
-random_process = OrnsteinUhlenbeckProcess(theta=.15, mu=0., sigma=.3, size=nb_actions)
-agent = ContinuousDQNAgent(nb_actions=nb_actions, V_model=V_model, L_model=L_model, mu_model=mu_model,
-                           memory=memory, nb_steps_warmup=100, random_process=random_process,
-                           gamma=.99, target_model_update=1e-3, processor=processor)
-agent.compile(Adam(lr=.001, clipnorm=1.), metrics=['mae'])
+    # Get the environment and extract the number of actions.
+    env = gym.make(ENV_NAME)
+    np.random.seed(123)
+    env.seed(123)
+    assert len(env.action_space.shape) == 1
+    nb_actions = env.action_space.shape[0]
 
-# Okay, now it's time to learn something! We visualize the training here for show, but this
-# slows down training quite a lot. You can always safely abort the training prematurely using
-# Ctrl + C.
-agent.fit(env, nb_steps=50000, visualize=True, verbose=1, nb_max_episode_steps=200)
+    # Build all necessary models: V, mu, and L networks.
+    V_model = Sequential()
+    V_model.add(Flatten(input_shape=(1,) + env.observation_space.shape))
+    V_model.add(Dense(16))
+    V_model.add(Activation('relu'))
+    V_model.add(Dense(16))
+    V_model.add(Activation('relu'))
+    V_model.add(Dense(16))
+    V_model.add(Activation('relu'))
+    V_model.add(Dense(1))
+    V_model.add(Activation('linear'))
+    print(V_model.summary())
 
-# After training is done, we save the final weights.
-agent.save_weights('cdqn_{}_weights.h5f'.format(ENV_NAME), overwrite=True)
+    mu_model = Sequential()
+    mu_model.add(Flatten(input_shape=(1,) + env.observation_space.shape))
+    mu_model.add(Dense(16))
+    mu_model.add(Activation('relu'))
+    mu_model.add(Dense(16))
+    mu_model.add(Activation('relu'))
+    mu_model.add(Dense(16))
+    mu_model.add(Activation('relu'))
+    mu_model.add(Dense(nb_actions))
+    mu_model.add(Activation('linear'))
+    print(mu_model.summary())
 
-# Finally, evaluate our algorithm for 5 episodes.
-agent.test(env, nb_episodes=10, visualize=True, nb_max_episode_steps=200)
+    action_input = Input(shape=(nb_actions,), name='action_input')
+    observation_input = Input(shape=(1,) + env.observation_space.shape, name='observation_input')
+    x = concatenate([action_input, Flatten()(observation_input)])
+    x = Dense(32)(x)
+    x = Activation('relu')(x)
+    x = Dense(32)(x)
+    x = Activation('relu')(x)
+    x = Dense(32)(x)
+    x = Activation('relu')(x)
+    x = Dense(((nb_actions * nb_actions + nb_actions) / 2))(x)
+    x = Activation('linear')(x)
+    L_model = Model(input=[action_input, observation_input], output=x)
+    print(L_model.summary())
+
+    # Finally, we configure and compile our agent. You can use every built-in Keras optimizer and
+    # even the metrics!
+    processor = PendulumProcessor()
+    memory = SequentialMemory(limit=100000, window_length=1)
+    random_process = OrnsteinUhlenbeckProcess(theta=.15, mu=0., sigma=.3, size=nb_actions)
+    agent = ContinuousDQNAgent(nb_actions=nb_actions, V_model=V_model, L_model=L_model, mu_model=mu_model,
+                               memory=memory, nb_steps_warmup=100, random_process=random_process,
+                               gamma=.99, target_model_update=1e-3, processor=processor)
+    agent.compile(Adam(lr=.001, clipnorm=1.), metrics=['mae'])
+
+    if args.load:
+        agent.load_weights(args.path)
+    else:
+        # Okay, now it's time to learn something! We visualize the training here for show, but this
+        # slows down training quite a lot. You can always safely abort the training prematurely using
+        # Ctrl + C.
+        agent.fit(env, nb_steps=args.steps, visualize=args.quiet, verbose=1, nb_max_episode_steps=200)
+
+        # After training is done, we save the final weights.
+        agent.save_weights(args.path, overwrite=True)
+
+    # Finally, evaluate our algorithm for 5 episodes.
+    agent.test(env, nb_episodes=10, visualize=True, nb_max_episode_steps=200)
+
+if __name__=="__main__":
+    main(sys.argv[1:])

--- a/rl/agents/dqn.py
+++ b/rl/agents/dqn.py
@@ -370,88 +370,43 @@ class NAFLayer(Layer):
         a = x[2]
 
         if self.mode == 'full':
-            # Create L and L^T matrix, which we use to construct the positive-definite matrix P.
-            L = None
-            LT = None
             if K.backend() == 'theano':
                 import theano.tensor as T
                 import theano
 
-                def fn(x, L_acc, LT_acc):
+                def fn(x, _):
                     x_ = K.zeros((self.nb_actions, self.nb_actions))
                     x_ = T.set_subtensor(x_[np.tril_indices(self.nb_actions)], x)
-                    diag = K.exp(T.diag(x_)) + K.epsilon()
-                    x_ = T.set_subtensor(x_[np.diag_indices(self.nb_actions)], diag)
-                    return x_, x_.T
+                    x_ = K.dot(x_, x_.T) + (K.epsilon()*T.eye(self.nb_actions))
+                    return x_
 
-                outputs_info = [
-                    K.zeros((self.nb_actions, self.nb_actions)),
-                    K.zeros((self.nb_actions, self.nb_actions)),
-                ]
-                results, _ = theano.scan(fn=fn, sequences=L_flat, outputs_info=outputs_info)
-                L, LT = results
+                outputs_info = [K.zeros((self.nb_actions, self.nb_actions))]
+                P, _ = theano.scan(fn=fn, sequences=L_flat, outputs_info=outputs_info)
             elif K.backend() == 'tensorflow':
                 import tensorflow as tf
 
-                # Number of elements in a triangular matrix.
-                nb_elems = (self.nb_actions * self.nb_actions + self.nb_actions) // 2
+                tril_indices = tf.constant(np.vstack(np.expand_dims(i,0) for i in np.tril_indices(self.nb_actions)))
+                p_shape = tf.constant([self.nb_actions, self.nb_actions])
 
-                # Create mask for the diagonal elements in L_flat. This is used to exponentiate
-                # only the diagonal elements, which is done before gathering.
-                diag_indeces = [0]
-                for row in range(1, self.nb_actions):
-                    diag_indeces.append(diag_indeces[-1] + (row + 1))
-                diag_mask = np.zeros(1 + nb_elems)  # +1 for the leading zero
-                diag_mask[np.array(diag_indeces) + 1] = 1
-                diag_mask = K.variable(diag_mask)
+                def fn(_, x):
+                    x_ = tf.scatter_nb(tril_indices, p_shape, x)
+                    x_ = K.dot(x_, tf.transpose(x_)) + (K.epsilon()*tf.eye(self.nb_actions))
+                    return x_
 
-                # Add leading zero element to each element in the L_flat. We use this zero
-                # element when gathering L_flat into a lower triangular matrix L.
-                nb_rows = tf.shape(L_flat)[0]
-                zeros = tf.expand_dims(tf.tile(K.zeros((1,)), [nb_rows]), 1)
-                try:
-                    # Old TF behavior.
-                    L_flat = tf.concat(1, [zeros, L_flat])
-                except TypeError:
-                    # New TF behavior
-                    L_flat = tf.concat([zeros, L_flat], 1)
-
-                # Create mask that can be used to gather elements from L_flat and put them
-                # into a lower triangular matrix.
-                tril_mask = np.zeros((self.nb_actions, self.nb_actions), dtype='int32')
-                tril_mask[np.tril_indices(self.nb_actions)] = range(1, nb_elems + 1)
-
-                # Finally, process each element of the batch.
                 init = [
                     K.zeros((self.nb_actions, self.nb_actions)),
                     K.zeros((self.nb_actions, self.nb_actions)),
                 ]
 
-                def fn(a, x):
-                    # Exponentiate everything. This is much easier than only exponentiating
-                    # the diagonal elements, and, usually, the action space is relatively low.
-                    x_ = K.exp(x) + K.epsilon()
-                    # Only keep the diagonal elements.
-                    x_ *= diag_mask
-                    # Add the original, non-diagonal elements.
-                    x_ += x * (1. - diag_mask)
-                    # Finally, gather everything into a lower triangular matrix.
-                    L_ = tf.gather(x_, tril_mask)
-                    return [L_, tf.transpose(L_)]
-
                 tmp = tf.scan(fn, L_flat, initializer=init)
                 if isinstance(tmp, (list, tuple)):
                     # TensorFlow 0.10 now returns a tuple of tensors.
-                    L, LT = tmp
+                    P = tmp[0]
                 else:
                     # Old TensorFlow < 0.10 returns a shared tensor.
-                    L = tmp[:, 0, :, :]
-                    LT = tmp[:, 1, :, :]
+                    P = tmp
             else:
                 raise RuntimeError('Unknown Keras backend "{}".'.format(K.backend()))
-            assert L is not None
-            assert LT is not None
-            P = K.batch_dot(L, LT)
         elif self.mode == 'diag':
             if K.backend() == 'theano':
                 import theano.tensor as T


### PR DESCRIPTION
Testing an alternative parameterization of P. It is just `x*x^T + epsilon*eye`. The eye is added after the dot instead of before. The diagonals are all squared values plus epsilon, so are >0.

Also added argparse to the cdqn example so it can train a new model or test an existing model. It looks like a ton of changes but it is mostly just changing the indentation.

I want to make sure to test the change thoroughly. Need to make sure it learns and runs as quickly and is at least as stable. Any ideas on benchmarking the actual performance of the cdqn?

Cheers