### PR TITLE
Save status observation and paddle initial states

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# ignore weights
+*.h5f

--- a/rl/agents/dqn.py
+++ b/rl/agents/dqn.py
@@ -214,6 +214,7 @@ class DQNAgent(AbstractDQNAgent):
         if self.training:
             action = self.policy.select_action(q_values=q_values)
         else:
+            self.save_current_state(state)
             action = self.test_policy.select_action(q_values=q_values)
         if self.processor is not None:
             action = self.processor.process_action(action)

--- a/rl/core.py
+++ b/rl/core.py
@@ -336,6 +336,12 @@ class Agent(object):
     def save_weights(self, filepath, overwrite=False):
         raise NotImplementedError()
 
+    def save_current_state(self, state, filepath="states/state_{}.png"):
+        assert type(state) == list
+        import scipy.misc
+        state_image = np.concatenate(tuple(state), axis=1)
+        scipy.misc.imsave(filepath.format(str(self.step)), state_image)
+
     @property
     def metrics_names(self):
         return []

--- a/rl/memory.py
+++ b/rl/memory.py
@@ -4,6 +4,7 @@ import warnings
 import random
 
 import numpy as np
+from copy import deepcopy
 
 
 # This is to be understood as a transition: Given `state0`, performing `action`
@@ -102,7 +103,8 @@ class Memory(object):
                 break
             state.insert(0, self.recent_observations[current_idx])
         while len(state) < self.window_length:
-            state.insert(0, zeroed_observation(state[0]))
+            state.insert(0, deepcopy(state[0]))
+            # state.insert(0, zeroed_observation(state[0]))
         return state
 
     def get_config(self):

--- a/states/text.txt
+++ b/states/text.txt
@@ -1,0 +1,1 @@
+states observed by the agent wil be saved in this folder


### PR DESCRIPTION
First commit saves status as image in a folder called 'states', only in training time. Only implemented in dqn_atari.py. Its helpful to see what our agent is watching while playing.

Second commit paddles states with last frame as it's advised [here](https://arxiv.org/pdf/1602.02658.pdf):

> We suggest to model initial states by replicating the state instead of padding it with zeroes and to model the terminal states in the network itself and not the target function

is esentially the same as the previous PR which I cancelled, but this includes a states folder to save states observed into it