### PR TITLE
Fix inconsistent sampled experiences in SequentialMemory

### DIFF
--- a/tests/rl/test_core.py
+++ b/tests/rl/test_core.py
@@ -56,54 +56,42 @@ def test_fit_observations():
     agent.fit(env, 20, verbose=0)
 
     # Inspect memory to see if observations are correct.
-    experiencies = memory.sample(batch_size=8, batch_idxs=range(8))
-    
-    assert experiencies[0].reward == .2
-    assert experiencies[0].action == 1
-    assert_allclose(experiencies[0].state0, np.array([0, 1]))
-    assert_allclose(experiencies[0].state1, np.array([1, 2]))
+    experiencies = memory.sample(batch_size=6, batch_idxs=range(2, 8))
+
+    assert experiencies[0].reward == .4
+    assert experiencies[0].action == 3
+    assert_allclose(experiencies[0].state0, np.array([2, 3]))
+    assert_allclose(experiencies[0].state1, np.array([3, 4]))
     assert experiencies[0].terminal1 is False
-    
-    assert experiencies[1].reward == .3
-    assert experiencies[1].action == 2
-    assert_allclose(experiencies[1].state0, np.array([1, 2]))
-    assert_allclose(experiencies[1].state1, np.array([2, 3]))
+
+    assert experiencies[1].reward == .5
+    assert experiencies[1].action == 4
+    assert_allclose(experiencies[1].state0, np.array([3, 4]))
+    assert_allclose(experiencies[1].state1, np.array([4, 5]))
     assert experiencies[1].terminal1 is False
 
-    assert experiencies[2].reward == .4
-    assert experiencies[2].action == 3
-    assert_allclose(experiencies[2].state0, np.array([2, 3]))
-    assert_allclose(experiencies[2].state1, np.array([3, 4]))
-    assert experiencies[2].terminal1 is False
+    assert experiencies[2].reward == .6
+    assert experiencies[2].action == 5
+    assert_allclose(experiencies[2].state0, np.array([4, 5]))
+    assert_allclose(experiencies[2].state1, np.array([5, 6]))
+    assert experiencies[2].terminal1 is True
 
-    assert experiencies[3].reward == .5
-    assert experiencies[3].action == 4
-    assert_allclose(experiencies[3].state0, np.array([3, 4]))
-    assert_allclose(experiencies[3].state1, np.array([4, 5]))
-    assert experiencies[3].terminal1 is False
-
-    assert experiencies[4].reward == .6
-    assert experiencies[4].action == 5
-    assert_allclose(experiencies[4].state0, np.array([4, 5]))
-    assert_allclose(experiencies[4].state1, np.array([5, 6]))
-    assert experiencies[4].terminal1 is True
-
-    # Experience 5 has been re-sampled since since state0 would be terminal in which case we
+    # Experience 3 has been re-sampled since since state0 would be terminal in which case we
     # cannot really have a meaningful transition because the environment gets reset. We thus
     # just ensure that state0 is not terminal.
-    assert not np.all(experiencies[5].state0 == np.array([5, 6]))
+    assert not np.all(experiencies[3].state0 == np.array([5, 6]))
 
-    assert experiencies[6].reward == .2
-    assert experiencies[6].action == 1
-    assert_allclose(experiencies[6].state0, np.array([0, 1]))
-    assert_allclose(experiencies[6].state1, np.array([1, 2]))
-    assert experiencies[6].terminal1 is False
+    assert experiencies[4].reward == .2
+    assert experiencies[4].action == 1
+    assert_allclose(experiencies[4].state0, np.array([0, 1]))
+    assert_allclose(experiencies[4].state1, np.array([1, 2]))
+    assert experiencies[4].terminal1 is False
 
-    assert experiencies[7].reward == .3
-    assert experiencies[7].action == 2
-    assert_allclose(experiencies[7].state0, np.array([1, 2]))
-    assert_allclose(experiencies[7].state1, np.array([2, 3]))
-    assert experiencies[7].terminal1 is False
+    assert experiencies[5].reward == .3
+    assert experiencies[5].action == 2
+    assert_allclose(experiencies[5].state0, np.array([1, 2]))
+    assert_allclose(experiencies[5].state1, np.array([2, 3]))
+    assert experiencies[5].terminal1 is False
 
 
 def test_copy_observations():
@@ -114,7 +102,7 @@ def test_copy_observations():
 
     for method in methods:
         original_observations = []
-        
+
         class LocalEnv(Env):
             def __init__(self):
                 super(LocalEnv, self).__init__()
@@ -155,7 +143,7 @@ def test_copy_observations():
         assert len(observations) == len(original_observations)
         assert_allclose(np.array(observations), np.array(original_observations))
         assert np.all([o is not o_ for o, o_ in zip(original_observations, observations)])
-    
+
 
 if __name__ == '__main__':
     pytest.main([__file__])

--- a/tests/rl/test_memory.py
+++ b/tests/rl/test_memory.py
@@ -43,7 +43,7 @@ def test_ring_buffer():
 def test_get_recent_state_with_episode_boundaries():
     memory = SequentialMemory(3, window_length=2, ignore_episode_boundaries=False)
     obs_size = (3, 4)
-    
+
     obs0 = np.random.random(obs_size)
     terminal0 = False
 
@@ -129,7 +129,7 @@ def test_training_flag():
         assert np.allclose(state[0], 0.)
         assert np.all(state[1] == obs0)
         assert memory.nb_entries == 0
-        
+
         memory.append(obs0, 0, 0., terminal1, training=training)
         state = np.array(memory.get_recent_state(obs1))
         assert state.shape == (2,) + obs_size
@@ -154,16 +154,16 @@ def test_training_flag():
 def test_get_recent_state_without_episode_boundaries():
     memory = SequentialMemory(3, window_length=2, ignore_episode_boundaries=True)
     obs_size = (3, 4)
-    
+
     obs0 = np.random.random(obs_size)
     terminal0 = False
-    
+
     obs1 = np.random.random(obs_size)
     terminal1 = False
-    
+
     obs2 = np.random.random(obs_size)
     terminal2 = False
-    
+
     obs3 = np.random.random(obs_size)
     terminal3 = True
 
@@ -175,7 +175,7 @@ def test_get_recent_state_without_episode_boundaries():
 
     obs6 = np.random.random(obs_size)
     terminal6 = False
-    
+
     state = np.array(memory.get_recent_state(obs0))
     assert state.shape == (2,) + obs_size
     assert np.allclose(state[0], 0.)
@@ -224,22 +224,22 @@ def test_sampling():
     memory = SequentialMemory(100, window_length=2, ignore_episode_boundaries=False)
     obs_size = (3, 4)
     actions = range(5)
-    
+
     obs0 = np.random.random(obs_size)
     terminal0 = False
     action0 = np.random.choice(actions)
     reward0 = np.random.random()
-    
+
     obs1 = np.random.random(obs_size)
     terminal1 = False
     action1 = np.random.choice(actions)
     reward1 = np.random.random()
-    
+
     obs2 = np.random.random(obs_size)
     terminal2 = False
     action2 = np.random.choice(actions)
     reward2 = np.random.random()
-    
+
     obs3 = np.random.random(obs_size)
     terminal3 = True
     action3 = np.random.choice(actions)
@@ -259,7 +259,7 @@ def test_sampling():
     terminal6 = False
     action6 = np.random.choice(actions)
     reward6 = np.random.random()
-    
+
     # memory.append takes the current observation, the reward after taking an action and if
     # the *new* observation is terminal, thus `obs0` and `terminal1` is correct.
     memory.append(obs0, action0, reward0, terminal1)
@@ -270,38 +270,26 @@ def test_sampling():
     memory.append(obs5, action5, reward5, terminal6)
     assert memory.nb_entries == 6
 
-    experiences = memory.sample(batch_size=5, batch_idxs=[0, 1, 2, 3, 4])
-    assert len(experiences) == 5
+    experiences = memory.sample(batch_size=3, batch_idxs=[2, 3, 4])
+    assert len(experiences) == 3
 
-    assert_allclose(experiences[0].state0, np.array([np.zeros(obs_size), obs0]))
-    assert_allclose(experiences[0].state1, np.array([obs0, obs1]))
-    assert experiences[0].action == action0
-    assert experiences[0].reward == reward0
-    assert experiences[0].terminal1 is False
-
-    assert_allclose(experiences[1].state0, np.array([obs0, obs1]))
-    assert_allclose(experiences[1].state1, np.array([obs1, obs2]))
-    assert experiences[1].action == action1
-    assert experiences[1].reward == reward1
-    assert experiences[1].terminal1 is False
-
-    assert_allclose(experiences[2].state0, np.array([obs1, obs2]))
-    assert_allclose(experiences[2].state1, np.array([obs2, obs3]))
-    assert experiences[2].action == action2
-    assert experiences[2].reward == reward2
-    assert experiences[2].terminal1 is True
+    assert_allclose(experiences[0].state0, np.array([obs1, obs2]))
+    assert_allclose(experiences[0].state1, np.array([obs2, obs3]))
+    assert experiences[0].action == action2
+    assert experiences[0].reward == reward2
+    assert experiences[0].terminal1 is True
 
     # Next experience has been re-sampled since since state0 would be terminal in which case we
     # cannot really have a meaningful transition because the environment gets reset. We thus
     # just ensure that state0 is not terminal.
-    assert not np.all(experiences[3].state0 == np.array([obs2, obs3]))
+    assert not np.all(experiences[1].state0 == np.array([obs2, obs3]))
 
-    assert_allclose(experiences[4].state0, np.array([np.zeros(obs_size), obs4]))
-    assert_allclose(experiences[4].state1, np.array([obs4, obs5]))
-    assert experiences[4].action == action4
-    assert experiences[4].reward == reward4
-    assert experiences[4].terminal1 is False
-    
+    assert_allclose(experiences[2].state0, np.array([np.zeros(obs_size), obs4]))
+    assert_allclose(experiences[2].state1, np.array([obs4, obs5]))
+    assert experiences[2].action == action4
+    assert experiences[2].reward == reward4
+    assert experiences[2].terminal1 is False
+
 
 if __name__ == '__main__':
     pytest.main([__file__])


### PR DESCRIPTION
This fixes two issues:

1. It is possible to sample an experience of the form (s0, a, r, s1, t) where s0 is terminal, when sampling the first item in the memory (because we can't tell whether it is terminal or not due to this info being in the previous item, which has been erased already).

2. For window_length > 1 it is possible for a state to contain zeroed observations, e.g. s0 = [0, 0, some_obs], even if "some_obs" is not the first observation in an episode. This happens when sampling among the first few entries in the memory, whose predecessors have been erased already.

The fix consists in ensuring we only sample items with index >= the minimum value to avoid both issues.