### PR TITLE
prevent double call of process_action

### DIFF
--- a/rl/agents/dqn.py
+++ b/rl/agents/dqn.py
@@ -219,8 +219,6 @@ class DQNAgent(AbstractDQNAgent):
             action = self.policy.select_action(q_values=q_values)
         else:
             action = self.test_policy.select_action(q_values=q_values)
-        if self.processor is not None:
-            action = self.processor.process_action(action)
 
         # Book-keeping.
         self.recent_observation = observation


### PR DESCRIPTION
There is a repeated call of process_action (once in forward and once in fit) and leads to unexpected behavior.