### PR TITLE
Fixed Breakout deprecated error for gym

### DIFF
--- a/examples/dqn_atari.py
+++ b/examples/dqn_atari.py
@@ -42,7 +42,7 @@ class AtariProcessor(Processor):
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--mode', choices=['train', 'test'], default='train')
-parser.add_argument('--env-name', type=str, default='BreakoutDeterministic-v3')
+parser.add_argument('--env-name', type=str, default='BreakoutDeterministic-v4')
 parser.add_argument('--weights', type=str, default=None)
 args = parser.parse_args()
 


### PR DESCRIPTION
Gym was not accepting v3 of breakout and gave the following error:

```
gym.error.DeprecatedEnv: Env BreakoutDeterministic-v3 not found (valid versions include ['BreakoutDeterministic-v0', 'BreakoutDeterministic-v4'])
```

Changing to v4, seems to fix the issue. Tested on Python 3.6.3, gym (0.9.4) and atari-py (0.1.1)