### PR TITLE
correct signature to be compatible with keras 2.0+

### DIFF
--- a/rl/util.py
+++ b/rl/util.py
@@ -90,8 +90,8 @@ class AdditionalUpdatesOptimizer(optimizers.Optimizer):
         self.optimizer = optimizer
         self.additional_updates = additional_updates
 
-    def get_updates(self, params, constraints, loss):
-        updates = self.optimizer.get_updates(params, constraints, loss)
+    def get_updates(self, params, loss):
+        updates = self.optimizer.get_updates(loss, params)
         updates += self.additional_updates
         self.updates = updates
         return self.updates


### PR DESCRIPTION
This would resolve the Keras 2.0+ compatibility issue listed [here](https://github.com/matthiasplappert/keras-rl/issues/143). Please let me know what you think? Thanks. 

Also I have noticed that the CI tests are mostly done with older versions of Keras. Please let me know what your plan is on supporting newer versions? 