### PR TITLE
Enabling dropout layers to be used in the actor and critic models.

### DIFF
--- a/rl/agents/ddpg.py
+++ b/rl/agents/ddpg.py
@@ -146,8 +146,13 @@ class DDPGAgent(Agent):
         # Finally, combine it all into a callable function.
         # if self.uses_learning_phase:
         # critic_inputs = [critic_inputs[0], K.learning_phase()]
-        self.actor_train_fn = K.function(critic_inputs + [K.learning_phase()],
-                                         [self.actor(critic_inputs)], updates=updates)
+        if K.backend() == 'tensorflow':
+            self.actor_train_fn = K.function(critic_inputs + [K.learning_phase()],
+                                             [self.actor(critic_inputs)], updates=updates)
+        else:
+            self.actor_train_fn = K.function(critic_inputs + [K.learning_phase()],
+                                             [self.actor(critic_inputs + [K.learning_phase()])],
+                                             updates=updates)
         self.actor_optimizer = actor_optimizer
 
         self.compiled = True

--- a/rl/agents/ddpg.py
+++ b/rl/agents/ddpg.py
@@ -145,8 +145,8 @@ class DDPGAgent(Agent):
 
         # Finally, combine it all into a callable function.
         # if self.uses_learning_phase:
-        #     critic_inputs += [K.learning_phase()]
-        self.actor_train_fn = K.function([critic_inputs, K.learning_phase()],
+        # critic_inputs = [critic_inputs[0], K.learning_phase()]
+        self.actor_train_fn = K.function(critic_inputs + [K.learning_phase()],
                                          [self.actor(critic_inputs)], updates=updates)
         self.actor_optimizer = actor_optimizer
 

--- a/rl/agents/ddpg.py
+++ b/rl/agents/ddpg.py
@@ -144,9 +144,10 @@ class DDPGAgent(Agent):
         updates += self.actor.updates  # include other updates of the actor, e.g. for BN
 
         # Finally, combine it all into a callable function.
-        if self.uses_learning_phase:
-            critic_inputs += [K.learning_phase()]
-        self.actor_train_fn = K.function(critic_inputs, [self.actor(critic_inputs)], updates=updates)
+        # if self.uses_learning_phase:
+        #     critic_inputs += [K.learning_phase()]
+        self.actor_train_fn = K.function([critic_inputs, K.learning_phase()],
+                                         [self.actor(critic_inputs)], updates=updates)
         self.actor_optimizer = actor_optimizer
 
         self.compiled = True

--- a/rl/agents/ddpg.py
+++ b/rl/agents/ddpg.py
@@ -144,15 +144,13 @@ class DDPGAgent(Agent):
         updates += self.actor.updates  # include other updates of the actor, e.g. for BN
 
         # Finally, combine it all into a callable function.
-        # if self.uses_learning_phase:
-        # critic_inputs = [critic_inputs[0], K.learning_phase()]
         if K.backend() == 'tensorflow':
             self.actor_train_fn = K.function(critic_inputs + [K.learning_phase()],
                                              [self.actor(critic_inputs)], updates=updates)
         else:
-            self.actor_train_fn = K.function(critic_inputs + [K.learning_phase()],
-                                             [self.actor(critic_inputs + [K.learning_phase()])],
-                                             updates=updates)
+            if self.uses_learning_phase:
+                critic_inputs += [K.learning_phase()]
+            self.actor_train_fn = K.function(critic_inputs, [self.actor(critic_inputs)], updates=updates)
         self.actor_optimizer = actor_optimizer
 
         self.compiled = True


### PR DESCRIPTION
The `K.learning_phase()` flag was not being passed correctly to `k.function()`, resulting in `AttributeError: 'Tensor' object has no attribute '_keras_shape' ` since the return value of `K.learning_phase()` was getting treated as normal input tensor to the model. This change fixes this. The reason for this is the segment `self.actor(critic_inputs)`. the actor should not receive `K.learning_phase()`