### PR TITLE
More logical order for clipped_masked_error's arguments

### DIFF
--- a/rl/agents/dqn.py
+++ b/rl/agents/dqn.py
@@ -180,7 +180,7 @@ class DQNAgent(AbstractDQNAgent):
         y_pred = self.model.output
         y_true = Input(name='y_true', shape=(self.nb_actions,))
         mask = Input(name='mask', shape=(self.nb_actions,))
-        loss_out = Lambda(clipped_masked_error, output_shape=(1,), name='loss')([y_pred, y_true, mask])
+        loss_out = Lambda(clipped_masked_error, output_shape=(1,), name='loss')([y_true, y_pred, mask])
         ins = [self.model.input] if type(self.model.input) is not list else self.model.input
         trainable_model = Model(inputs=ins + [y_true, mask], outputs=[loss_out, y_pred])
         assert len(trainable_model.output_names) == 2


### PR DESCRIPTION
This does not change the model since the Huber loss is symmetric, but it makes the code more readable.

(This is because clipped_masked_error is defined with arguments in this order: y_true, y_pred, mask)