### PR TITLE
Validation intervals during training, separate exploration noise for each action in DDPG, Random agent 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ install:
   # Useful for debugging any issues with conda
   - conda info -a
 
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy matplotlib pandas pytest h5py
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy matplotlib pandas pytest h5py
   - source activate test-environment
   - pip install pytest-xdist
   # See https://github.com/pytest-dev/pytest-cov/issues/124 for details
@@ -44,7 +44,8 @@ install:
   - pip install tensorflow
   # Bleeding-edge: pip install git+https://github.com/Theano/Theano.git
   - pip install "theano<1.0"
-  - pip install gym
+  - pip install gym==0.9.5
+  - pip install scipy
   # Bleeding-edge: pip install git+https://github.com/fchollet/keras.git;
   - pip install "keras>=2.0.7";
   - python setup.py install

--- a/rl/agents/random.py
+++ b/rl/agents/random.py
@@ -1,0 +1,28 @@
+from rl.core import Agent
+from rl.util import *
+
+
+class RandomAgent(Agent):
+    def __init__(self, nb_actions):
+        self.nb_actions = nb_actions
+        self.compiled = False
+        super(RandomAgent, self).__init__()
+
+    def forward(self, observation):
+        return np.random.randint(self.nb_actions)
+
+    def backward(self, reward, terminal):
+        pass
+
+    def compile(self, optimizer, metrics=[]):
+        self.compiled = True
+
+    def load_weights(self, filepath):
+        pass
+
+    def save_weights(self, filepath, overwrite=False):
+        pass
+
+    @property
+    def layers(self):
+        return None

--- a/rl/callbacks.py
+++ b/rl/callbacks.py
@@ -88,6 +88,9 @@ class CallbackList(KerasCallbackList):
 
 
 class TestLogger(Callback):
+    def __init__(self):
+        self.episode_reward = []
+
     def on_train_begin(self, logs):
         print('Testing for {} episodes ...'.format(self.params['nb_episodes']))
 
@@ -98,6 +101,14 @@ class TestLogger(Callback):
             logs['episode_reward'],
             logs['nb_steps'],
         ]
+        print(template.format(*variables))
+        self.episode_reward.append(variables[1])
+
+    def on_train_end(self, logs):
+        avg_reward = np.mean(self.episode_reward)
+        reward_var = np.var(self.episode_reward)
+        template = 'Average reward: {0:.3f}, reward variance: {1:.3f}'
+        variables = [avg_reward, reward_var]
         print(template.format(*variables))
 
 
@@ -242,7 +253,7 @@ class TrainIntervalLogger(Callback):
         if self.info_names is None:
             self.info_names = logs['info'].keys()
         values = [('reward', logs['reward'])]
-        self.progbar.update((self.step % self.interval) + 1, values=values, force=True)
+        self.progbar.update((self.step % self.interval) + 1, values=values)
         self.step += 1
         self.metrics.append(logs['metrics'])
         if len(self.info_names) > 0:

--- a/rl/core.py
+++ b/rl/core.py
@@ -41,7 +41,7 @@ class Agent(object):
         """
         return {}
 
-    def fit(self, env, nb_steps, test_nb_episodes, action_repetition=1, callbacks=None, verbose=1,
+    def fit(self, env, nb_steps, test_nb_episodes=1, action_repetition=1, callbacks=None, verbose=1,
             visualize=False, nb_max_start_steps=0, start_step_policy=None, log_interval=10000,
             nb_max_episode_steps=None, test_interval=10000, test_action_repetition=1, test_visualize=True,
             test_nb_max_episode_steps=None, test_nb_max_start_steps=0, test_start_step_policy=None,


### PR DESCRIPTION
Added ability to perform validation during training every `test_interval` number of steps.
Example:
```
fit(env, nb_steps, action_repetition=4, callbacks=callbacks, verbose=1, log_interval=5000, 
test_interval=50000, test_nb_episodes=10, test_action_repetition=4, test_visualize=True)
```

Added ability for each action to have its own random process for exploration noise. You can do this by passing a `list` or `tuple` of random processes. 
Example:
```
self.random_process = []
self.random_process.append(GaussianWhiteNoiseProcess(mu=1.5, sigma=0.5))  # action 1
self.random_process.append(GaussianWhiteNoiseProcess(mu=0.0, sigma=1.0))  # action 2
```
